### PR TITLE
Introduce Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
[Lifted][] from Rails `main`. This will be in the next release.

[Lifted]: https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml
