### PR TITLE
Introduce `capybara_accessibility_audit`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,5 +69,6 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  gem "capybara_accessibility_audit", github: "thoughtbot/capybara_accessibility_audit"
   gem "selenium-webdriver"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,12 +100,29 @@ GIT
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
 
+GIT
+  remote: https://github.com/thoughtbot/capybara_accessibility_audit.git
+  revision: 131bbb65c60519dbe804c031487b0dc427c15195
+  specs:
+    capybara_accessibility_audit (0.2.0)
+      axe-core-api
+      capybara
+      rails (>= 6.1)
+      zeitwerk
+
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    axe-core-api (4.9.0)
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     bigdecimal (3.1.7)
     bindex (0.8.1)
@@ -123,6 +140,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -130,12 +149,16 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     drb (2.2.1)
+    dumb_delegator (1.0.0)
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -270,6 +293,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.0)
     thor (1.3.1)
+    thread_safe (0.3.6)
     timeout (0.4.1)
     turbo-rails (2.0.5)
       actionpack (>= 6.0.0)
@@ -278,6 +302,10 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -304,6 +332,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  capybara_accessibility_audit!
   debug
   importmap-rails
   jbuilder


### PR DESCRIPTION
We reference `github` in order to use the latest build, which is
different than the latest release.