### PR TITLE
Revert "Bump selenium-webdriver from 4.19.0 to 4.20.0 (#3)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    selenium-webdriver (4.20.0)
+    selenium-webdriver (4.19.0)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)


### PR DESCRIPTION
This reverts commit 038b94d8283cb204cd711c1292f55af98a38e708.

Fixes the following error when running a system test:

```
undefined method `path' for class Selenium::WebDriver::DriverFinder (NoMethodError)
namespace::Service.driver_path = ::Selenium::WebDriver::DriverFinder.path(options, namespace::Service)
```
