### PR TITLE
Introduce basic homepage

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -1,0 +1,5 @@
+class AuditsController < ApplicationController
+  def new
+    @audit = Audit.new(params.fetch(:audit, {}).permit(:url))
+  end
+end

--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -1,0 +1,2 @@
+module AuditsHelper
+end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -1,0 +1,6 @@
+class Audit
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :url
+end

--- a/app/views/audits/new.html.erb
+++ b/app/views/audits/new.html.erb
@@ -1,0 +1,11 @@
+<% if @audit.url %>
+  <h1>Results for <%= @audit.url %></h1>
+<% else %>
+  <h1>Free Broken Link Checker</h1>
+<% end %>
+
+<%= form_with model: @audit, url: new_audit_path, method: :get do |form| %>
+  <%= form.label :url %>
+  <%= form.url_field :url, required: true %>
+  <%= form.submit "Audit Webpage" %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang=<%= I18n.locale %>>
   <head>
     <title>SimpleSiteStatus</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -11,6 +11,8 @@
   </head>
 
   <body>
-    <%= yield %>
+    <main>
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "audits#new"
+
+  resources :audits, only: %i[new]
 end

--- a/test/models/audit_test.rb
+++ b/test/models/audit_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class AuditTest < ActiveSupport::TestCase
+  test "url attribute" do
+    audit = Audit.new(url: "https://expected.com")
+
+    assert_equal "https://expected.com", audit.url
+  end
+end

--- a/test/system/audit_stories_test.rb
+++ b/test/system/audit_stories_test.rb
@@ -1,0 +1,14 @@
+require "application_system_test_case"
+
+class AuditStoriesTest < ApplicationSystemTestCase
+  test "auditing a url" do
+    visit root_path
+
+    assert_selector "h1", text: "Free Broken Link Checker"
+
+    fill_in "Url", with: "https://example.com"
+    click_button "Audit Webpage"
+
+    assert_selector "h1", text: "Results for https://example.com"
+  end
+end


### PR DESCRIPTION
Introduces `Audit` model and controller. In an effort to make the
simplest [vertical slice][] possible, our form simply makes a `GET`
request that does nothing.

This at least gives up a small foundation to build from, without
committing to too much.

Adds `lang` attribute and `<main>` landmark to fix a11y violations.

[vertical slice]: https://thoughtbot.com/blog/break-apart-your-features-into-full-stack-slices
